### PR TITLE
nvm installation not required anymore, removed npm installation line

### DIFF
--- a/setup-dotnet-dev.sh
+++ b/setup-dotnet-dev.sh
@@ -1,34 +1,30 @@
 #!/bin/bash
 
+## Updating the server and installing xubuntu GUI
 apt update
-apt-get upgrade
+apt upgrade -y
 export DEBIAN_FRONTEND=noninteractive
 apt-get install xubuntu-core -y
 
+## Installing VNC Server
 apt-get install x2goserver x2goserver-xsession -y
 
+curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+sudo apt-get install -y nodejs
+
+## Dev Environment
 snap install --classic code
-snap install --classic dotnet-sdk
-snap install rider --classic
 
+## Setting up the new user and generating random password
 
-# teamviewer
-cd /tmp
-wget https://download.teamviewer.com/download/linux/signature/TeamViewer2017.asc
-apt-key add TeamViewer2017.asc
-sh -c 'echo "deb http://linux.teamviewer.com/deb stable main" >> /etc/apt/sources.list.d/teamviewer.list'
-apt update
-#apt install teamviewer -y #has interactive question ... 
-#firewall port for teamviewer
-ufw allow 5938
-# => does not work right now
-
-# user login
+clear
+pass="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c16)"
+echo "[INFO] Generating random password"
 useradd developer -d /home/developer -m ;
-echo -e "RH02JGUGIgQbwQViMW\nRH02JGUGIgQbwQViMW" | passwd developer
+echo -e "$pass\n$pass" | passwd developer
 usermod --shell /bin/bash developer
+echo "############################################"
 echo "the account is setup"
+echo "Your new Password for developer is : $pass"
+echo "############################################"
 usermod -aG sudo developer
-
-#echo 'export DOTNET_ROOT="/snap/dotnet-sdk/current"' >> "/home/developer/.bashrc"
-

--- a/setup-dotnet-dev.sh
+++ b/setup-dotnet-dev.sh
@@ -1,30 +1,33 @@
 #!/bin/bash
 
-## Updating the server and installing xubuntu GUI
 apt update
-apt upgrade -y
+apt-get upgrade
 export DEBIAN_FRONTEND=noninteractive
 apt-get install xubuntu-core -y
 
-## Installing VNC Server
 apt-get install x2goserver x2goserver-xsession -y
 
-curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
-sudo apt-get install -y nodejs
-
-## Dev Environment
 snap install --classic code
+snap install --classic dotnet-sdk
+snap install rider --classic
 
-## Setting up the new user and generating random password
 
-clear
-pass="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c16)"
-echo "[INFO] Generating random password"
+# teamviewer
+cd /tmp
+wget https://download.teamviewer.com/download/linux/signature/TeamViewer2017.asc
+apt-key add TeamViewer2017.asc
+sh -c 'echo "deb http://linux.teamviewer.com/deb stable main" >> /etc/apt/sources.list.d/teamviewer.list'
+apt update
+#apt install teamviewer -y #has interactive question ... 
+#firewall port for teamviewer
+ufw allow 5938
+# => does not work right now
+
+# user login
 useradd developer -d /home/developer -m ;
-echo -e "$pass\n$pass" | passwd developer
+echo -e "RH02JGUGIgQbwQViMW\nRH02JGUGIgQbwQViMW" | passwd developer
 usermod --shell /bin/bash developer
-echo "############################################"
 echo "the account is setup"
-echo "Your new Password for developer is : $pass"
-echo "############################################"
 usermod -aG sudo developer
+
+#echo 'export DOTNET_ROOT="/snap/dotnet-sdk/current"' >> "/home/developer/.bashrc"

--- a/setup.sh
+++ b/setup.sh
@@ -1,31 +1,30 @@
 #!/bin/bash
 
+## Updating the server and installing xubuntu GUI
 apt update
 apt upgrade -y
 export DEBIAN_FRONTEND=noninteractive
 apt-get install xubuntu-core -y
 
+## Installing VNC Server
 apt-get install x2goserver x2goserver-xsession -y
 
-# install nvm
-#curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
-#nvm install 14.15.3
+curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+sudo apt-get install -y nodejs
 
-#curl -sL https://deb.nodesource.com/setup_15.x | sudo bash -
-# sudo apt-get install -y nodejs
-# node -v
-
-apt install nodejs npm -y
-# dependency for nexe...
-#apt-get install python2 -y
-
-# dev environment
+## Dev Environment
 snap install --classic code
 
+## Setting up the new user and generating random password
 
-
+clear
+pass="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c16)"
+echo "[INFO] Generating random password"
 useradd developer -d /home/developer -m ;
-echo -e "RH02JGUGIgQbwQViMW\nRH02JGUGIgQbwQViMW" | passwd developer
+echo -e "$pass\n$pass" | passwd developer
 usermod --shell /bin/bash developer
+echo "############################################"
 echo "the account is setup"
+echo "Your new Password for developer is : $pass"
+echo "############################################"
 usermod -aG sudo developer


### PR DESCRIPTION
Hey Stefan, 

so I did some testing and now everything is working and github is creating the builds successfully. I switched to pkg over nexe since nexe was just a pain. I found out that nvm installs and switches to the node version that we want only for the current terminal we are woirking on so it does not help that much. `curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -` installs the LTS node with the appropiate npm version for best compatibality so no need for the npm installation line.  Also the setup.sh now generates a random password so that our password isn't public anymore xD 